### PR TITLE
Reflect changes in Frenetic 4.0.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,4 @@
-Vagrant.require_version ">= 1.6.0", "< 1.7.0"
+Vagrant.require_version ">= 1.6.0"
 
 Vagrant.configure("2") do |config|
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,4 @@
-Vagrant.require_version ">= 1.6.0"
+Vagrant.require_version ">= 1.6.0", "< 1.7.0"
 
 Vagrant.configure("2") do |config|
 

--- a/root-bootstrap.sh
+++ b/root-bootstrap.sh
@@ -6,6 +6,7 @@ apt-get update
 apt-get install -y \
   wireshark \
   m4 \
+  mininet \
   git \
   xterm \
   fortune \
@@ -19,13 +20,6 @@ apt-get install -y \
   python-pycurl \
   python-networkx \
   software-properties-common \
-
-# Install Mininet from source to get the latest version, > 2.2.1.  The API on the packaged version, 2.1, doesn't work
-# with the latest openvswitch.  https://github.com/frenetic-lang/frenetic-vm/issues/4
-cd /usr/local/src
-git clone git://github.com/mininet/mininet
-cd mininet
-util/install.sh -nfv
 
 add-apt-repository -y ppa:avsm/ppa
 apt-get update

--- a/root-bootstrap.sh
+++ b/root-bootstrap.sh
@@ -4,7 +4,6 @@ set -x
 apt-get update
 
 apt-get install -y \
-  wireshark \
   m4 \
   mininet \
   git \
@@ -20,6 +19,11 @@ apt-get install -y \
   python-pycurl \
   python-networkx \
   software-properties-common \
+
+# Necessary to get Wireshark 1.12 with OpenFlow support in Ubuntu 14.04
+add-apt-repository -y ppa:wireshark-dev/stable
+apt-get update
+apt-get install -y wireshark
 
 add-apt-repository -y ppa:avsm/ppa
 apt-get update

--- a/root-bootstrap.sh
+++ b/root-bootstrap.sh
@@ -6,7 +6,6 @@ apt-get update
 apt-get install -y \
   wireshark \
   m4 \
-  mininet \
   git \
   xterm \
   fortune \
@@ -20,6 +19,13 @@ apt-get install -y \
   python-pycurl \
   python-networkx \
   software-properties-common \
+
+# Install Mininet from source to get the latest version, > 2.2.1.  The API on the packaged version, 2.1, doesn't work
+# with the latest openvswitch.  https://github.com/frenetic-lang/frenetic-vm/issues/4
+cd /usr/local/src
+git clone git://github.com/mininet/mininet
+cd mininet
+util/install.sh -nfv
 
 add-apt-repository -y ppa:avsm/ppa
 apt-get update

--- a/user-bootstrap.sh
+++ b/user-bootstrap.sh
@@ -9,15 +9,9 @@ echo 'eval `opam config env`' >> /home/vagrant/.profile
 opam install -y ulex cmdliner ocamlgraph quickcheck async yojson cohttp base64
 
 cd src
-git clone https://github.com/frenetic-lang/ocaml-packet
-git clone https://github.com/frenetic-lang/ocaml-topology
-git clone https://github.com/frenetic-lang/ocaml-openflow
 git clone https://github.com/frenetic-lang/frenetic
 cd ..
 
-opam pin add packet src/ocaml-packet -n -k git
-opam pin add topology src/ocaml-topology -n -k git
-opam pin add openflow src/ocaml-openflow -n -k git
 opam pin add frenetic src/frenetic -n -k git
 
 opam install -y frenetic

--- a/user-bootstrap.sh
+++ b/user-bootstrap.sh
@@ -9,9 +9,15 @@ echo 'eval `opam config env`' >> /home/vagrant/.profile
 opam install -y ulex cmdliner ocamlgraph quickcheck async yojson cohttp base64
 
 cd src
+git clone https://github.com/frenetic-lang/ocaml-packet
+git clone https://github.com/frenetic-lang/ocaml-topology
+git clone https://github.com/frenetic-lang/ocaml-openflow
 git clone https://github.com/frenetic-lang/frenetic
 cd ..
 
+opam pin add packet src/ocaml-packet -n -k git
+opam pin add topology src/ocaml-topology -n -k git
+opam pin add openflow src/ocaml-openflow -n -k git
 opam pin add frenetic src/frenetic -n -k git
 
 opam install -y frenetic

--- a/user-bootstrap.sh
+++ b/user-bootstrap.sh
@@ -6,18 +6,12 @@ opam init -y
 eval `opam config env`
 echo 'eval `opam config env`' >> /home/vagrant/.profile
 
-opam install -y ulex cmdliner ocamlgraph quickcheck async yojson cohttp base64
+opam install -y ulex cmdliner ocamlgraph quickcheck async yojson cohttp base64 mparser
 
 cd src
-git clone https://github.com/frenetic-lang/ocaml-packet
-git clone https://github.com/frenetic-lang/ocaml-topology
-git clone https://github.com/frenetic-lang/ocaml-openflow
 git clone https://github.com/frenetic-lang/frenetic
 cd ..
 
-opam pin add packet src/ocaml-packet -n -k git
-opam pin add topology src/ocaml-topology -n -k git
-opam pin add openflow src/ocaml-openflow -n -k git
 opam pin add frenetic src/frenetic -n -k git
 
 opam install -y frenetic


### PR DESCRIPTION
Since the repos have been merged in, there's no need to build them separately.  These changes should be merged in only after Frenetic unified branch has been merged.  
