### PR TITLE
Added emacs and vim modeline to Vagrantfile.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,6 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
 Vagrant.require_version ">= 1.6.0"
 
 Vagrant.configure("2") do |config|


### PR DESCRIPTION
Vagrantfiles are really ruby scripts, but when you open a Vagrantfile in
emacs or vim, it's unlikely that it will recognize it as a ruby script.
As a result, your text editor is unlikely to syntax highlight the
Vagrantfile. This can be remedied by including an emacs and vim modeline
at the top of the script which will inform your text editor that it's
editing a ruby file. In fact, when you create a default Vagrantfile
using `vagrant init`, it includes the modelines at the top of the
Vagrantfile for you. This [superuser question](http://superuser.com/q/703803) has more information
on the behaviour of the modelines.
