### PR TITLE
Add Python Bindings Install

### DIFF
--- a/user-bootstrap.sh
+++ b/user-bootstrap.sh
@@ -13,3 +13,5 @@ cd ..
 opam pin add frenetic src/frenetic -n -k git
 
 opam install -y frenetic
+
+sudo pip install -e  src/frenetic/lang/python


### PR DESCRIPTION
As part of provisioning, install Frenetic Python bindings.   Similar to OPAM-pinning the OCaml Frenetic package, we pin the PIP version of the python bindings to the source tree.  That way when the bindings are updated, you just have to refresh the Git sandbox.  

This allows us to remove the annoying lines from all the code samples in the Frenetic Programmers Manual:

```
import sys
sys.path.append("~/src/frenetic/lang/python")
```
