### PR TITLE
Fixes compiler incompatibility introduced by requiring 4.03.0.

### DIFF
--- a/user-bootstrap.sh
+++ b/user-bootstrap.sh
@@ -2,7 +2,7 @@
 set -x
 set -e
 
-opam init -y
+opam init -y --comp 4.03.0
 eval `opam config env`
 echo 'eval `opam config env`' >> $HOME/.profile
 


### PR DESCRIPTION
Required OCaml version for frenetic-lang/frenetic was updated to 4.03.0
by 07d8610f4174214a1e2723a934118ea6e589bcea. This commit fixes the
no-compile thus introduced.
